### PR TITLE
Adjust Plugin for Java 17, Minor fixes & UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,8 @@ the following format within the job working directory: 
 -	Added Support in Java 17
 -	Resolved the problem where the user password was being reset after every configuration save
 -	Move the PostStep Report to stream directly from the server to the disk
+-	Adjusted tables and icons to Jenkins new CSS
+-	Enabled CD (Continuous Delivery)
 
 ##### Version 3.2.1.6 (Feb 8, 2024)
 -	Fix - Exit criteria for a single session execution with state \"Failed\" didn\'t trigger when session ended

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>vmanager-plugin</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>${revision}-${changelist}</version>
   <packaging>hpi</packaging>
   <description>Integrates Jenkins to Cadence vManager</description>
   <url>https://github.com/jenkinsci/vmanager-plugin</url>
@@ -22,7 +22,7 @@
   
   <properties>
     <revision>4.0.0</revision>
-    <changelist>-SNAPSHOT</changelist>
+    <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/vmanager-plugin</gitHubRepo>
     <findbugs.failOnError>false</findbugs.failOnError>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
@@ -113,16 +113,4 @@
   	<url>www.cadence.com</url>
   </organization>
   <name>Cadence vManager Plugin for Jenkins</name>
-    <!--build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <debug>false</debug>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build-->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,10 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
     </dependency>
-
+    <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>ionicons-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -107,6 +110,7 @@
         <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
   </dependencies>
+ 
  
   <organization>
   	<name>Cadence</name>

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/VMGRLaunchStepImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/VMGRLaunchStepImpl.java
@@ -17,7 +17,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 public class VMGRLaunchStepImpl extends SynchronousNonBlockingStepExecution {
 
-    private static final long serialVersionUID = 1000009076155338045L;
+    private static final long serialVersionUID = 1000009076155338046L;
     
     private transient final VMGRLaunchStep step;
 

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLBuildAction.java
@@ -19,7 +19,7 @@ import org.jenkinsci.plugins.vmanager.VMGRRun;
 
 public class DSLBuildAction extends PostActionBase implements Serializable, RunAction2,  SimpleBuildStep.LastBuildAction  {
 
-    private static final long serialVersionUID = 2000009076155338045L;
+    private static final long serialVersionUID = 2000009076155338046L;
     
     private String message;
     private transient Run<?, ?> build;
@@ -27,7 +27,7 @@ public class DSLBuildAction extends PostActionBase implements Serializable, RunA
 
     @Override
     public String getIconFileName() {
-        return "/plugin/vmanager-plugin/img/weblinks.png";
+        return "symbol-link-outline plugin-ionicons-api";
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLProjectAction.java
@@ -14,12 +14,12 @@ import org.jenkinsci.plugins.vmanager.VMGRRun;
 
 public class DSLProjectAction extends PostActionBase implements Serializable, Action {
 
-    private static final long serialVersionUID = 3000009076155338045L;
+    private static final long serialVersionUID = 3000009076155338046L;
     private transient  Job<?, ?> project;
 
     @Override
     public String getIconFileName() {
-        return "/plugin/vmanager-plugin/img/project_icon.png";
+        return "symbol-list-outline plugin-ionicons-api";
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLPublisher.java
@@ -40,7 +40,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 public class DSLPublisher extends Recorder implements SimpleBuildStep, Serializable {
 
-    private static final long serialVersionUID = 4000009076155338045L;
+    private static final long serialVersionUID = 4000009076155338046L;
     private transient Run<?, ?> build;
 
     private String vAPIUrl;

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/ReportBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/ReportBuildAction.java
@@ -15,7 +15,7 @@ import org.jenkinsci.plugins.vmanager.VAPIConnectionParam;
 
 public class ReportBuildAction extends PostActionBase implements Serializable, RunAction2 {
     
-    private static final long serialVersionUID = 5000009076155338045L;
+    private static final long serialVersionUID = 5000009076155338046L;
     private transient Run<?, ?> build;
     private transient TaskListener listener;
     private transient ReportManager reportManager;
@@ -28,7 +28,7 @@ public class ReportBuildAction extends PostActionBase implements Serializable, R
     
     @Override 
     public String getIconFileName() {
-        return "/plugin/vmanager-plugin/img/report.png";
+        return "symbol-checkbox-outline plugin-ionicons-api";
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/VMGRPostLaunchStepImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/VMGRPostLaunchStepImpl.java
@@ -12,7 +12,7 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
 public class VMGRPostLaunchStepImpl extends SynchronousNonBlockingStepExecution<Void> {
     
-   private static final long serialVersionUID = 6000009076155338045L;
+   private static final long serialVersionUID = 6000009076155338046L;
    private transient final VMGRPostLaunchStep step;
    
    VMGRPostLaunchStepImpl(VMGRPostLaunchStep step, StepContext context) {

--- a/src/main/resources/hudson/plugins/vmanager/VmgrBuilds/portlet.jelly
+++ b/src/main/resources/hudson/plugins/vmanager/VmgrBuilds/portlet.jelly
@@ -1,10 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <dp:decorate portlet="${it}">
-    <tr><td>
-      <div align="center">
+  <dp:decorate-table portlet="${it}" class="sortable jenkins-table--small">
 		<st:include page="vmgrbuilds.jelly"/>
-       </div>
-     </td></tr>
-  </dp:decorate>
+  </dp:decorate-table>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/vmanager/VmgrBuilds/vmgrbuilds.jelly
+++ b/src/main/resources/hudson/plugins/vmanager/VmgrBuilds/vmgrbuilds.jelly
@@ -1,58 +1,52 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-         xmlns:dp="/hudson/plugins/view/dashboard">
-    <j:set var="iconSize" value="16x16" />
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
     <j:set var="builds" value="${it.finishedVMGRBuilds}" />
-    <table id="statistics" class="sortable pane bigtable"
-                               style="margin-top: 0px;">
-        <tr style="border-top: 0px;">
-            <th tooltip="${%Build name}" align="left">${%Build name}</th>
+		<thead id="statistics" >
+        <tr>
+			<th tooltip="${%Build name}" align="left">${%Build name}</th>
             <th tooltip="${%Build status}" align="left">${%Build status}</th>
-	    <th tooltip="${%Build time}" align="left">${%Build time}</th>
-	    <th tooltip="${%Build owner}" align="left">${%Build owner}</th>
+			<th tooltip="${%Build time}" align="left">${%Build time}</th>
+			<th tooltip="${%Build owner}" align="left">${%Build owner}</th>
             <th tooltip="${%Build sessionstatus}" align="left">${%Build sessionstatus}</th>
-	    <th tooltip="${%Build sessiontriage}" align="left">${%Build sessiontriage}</th>
+			<th tooltip="${%Build sessiontriage}" align="left">${%Build sessiontriage}</th>
             <th tooltip="${%Build sessionname}" align="left">${%Build sessionname}</th>
-	    <th tooltip="${%Build totalruns}" align="left">${%Build totalruns}</th>
+			<th tooltip="${%Build totalruns}" align="left">${%Build totalruns}</th>
             <th tooltip="${%Build passed}" align="left">${%Build passed}</th>
             <th tooltip="${%Build failed}" align="left">${%Build failed}</th>
-	    <th tooltip="${%Build running}" align="left">${%Build running}</th>
+			<th tooltip="${%Build running}" align="left">${%Build running}</th>
             <th tooltip="${%Build waiting}" align="left">${%Build waiting}</th>
             <th tooltip="${%Build other}" align="left">${%Build other}</th>
-	    <th tooltip="${%Build numofsessions}" align="left">${%Build numofsessions}</th>
-
-	    
+			<th tooltip="${%Build numofsessions}" align="left">${%Build numofsessions}</th>
         </tr>
-        <j:forEach var="build" items="${builds}">
-            <tr>
-                <td style="border: 1px #bbb solid;">
-                    <!-- This tag does not generate a job link relative to view for jobs included using regexp -->
-                    <!--t:jobLink job="${build.getRun().parent}"/-->
-                    <dp:jobLink job="${build.getRun().parent}"/>
-                </td>
-                <td style="border: 1px #bbb solid;" data="${it.getBuildColumnSortData(build)}">
-                    <a href="${h.getRelativeLinkTo(build.getRun().parent)}/${build.getRun().number}" >
-                        <img src="${imagesURL}/16x16/${build.getRun().buildStatusUrl}"
-                     alt="${build.getRun().iconColor.description}"
-                     title="${build.getRun().iconColor.description}" />${build.getRun().displayName}
-                    </a>
-                </td>
-		<td style="border: 1px #bbb solid;" data="${it.getTimestampString(build)}">${it.getTimestampString(build)}</td>
-                <td style="border: 1px #bbb solid;" data="${it.getBuildOwner(build)}">${it.getBuildOwner(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getSessionStatus(build)}">${it.getSessionStatus(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getSessionTriage(build)}"><a target="_blank" href="${it.getSessionTriage(build)}" tooltip="A Link to Verisium Manager Web Regression">Link</a></td>		
-		<td style="border: 1px #bbb solid;" data="${it.getSessionName(build)}">${it.getSessionName(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getTotalRuns(build)}">${it.getTotalRuns(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getPassedRuns(build)}">${it.getPassedRuns(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getFailedRuns(build)}">${it.getFailedRuns(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getRunningRuns(build)}">${it.getRunningRuns(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getWaitingRuns(build)}">${it.getWaitingRuns(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getOtherRuns(build)}">${it.getOtherRuns(build)}</td>
-		<td style="border: 1px #bbb solid;" data="${it.getTotalSessions(build)}">${it.getTotalSessions(build)}</td>
+		</thead>
+		<tbody>
+			<j:forEach var="build" items="${builds}">
+				<tr>
+					<td><div class="dbv-cell"><t:jobLink job="${build.getRun().parent}"/></div></td>
+					<td data="${it.getBuildColumnSortData(build)}">
+						<div class="dbv-cell">
+						  <l:icon alt="${build.getRun().iconColor.description}"
+								  class="${build.getRun().buildStatusIconClassName} icon-sm"/>
+						  <a href="${h.getRelativeLinkTo(build.getRun().parent)}/${build.getRun().number}" class="model-link"
+							tooltip="${empty(build.getRun().description) ? null : app.markupFormatter.translate(build.getRun().description)}">
+							${build.getRun().displayName}
+						  </a>
+						</div>
+					</td>
+					<td data="${it.getTimestampSortData(build)}">${it.getTimestampString(build)}</td>
+					<td data="${it.getBuildOwner(build)}">${it.getBuildOwner(build)}</td>
+					<td data="${it.getSessionStatus(build)}">${it.getSessionStatus(build)}</td>
+					<td data="${it.getSessionTriage(build)}"><a target="_blank" href="${it.getSessionTriage(build)}" tooltip="A Link to Verisium Manager Web Regression">Link</a></td>		
+					<td data="${it.getSessionName(build)}">${it.getSessionName(build)}</td>
+					<td data="${it.getTotalRuns(build)}">${it.getTotalRuns(build)}</td>
+					<td data="${it.getPassedRuns(build)}">${it.getPassedRuns(build)}</td>
+					<td data="${it.getFailedRuns(build)}">${it.getFailedRuns(build)}</td>
+					<td data="${it.getRunningRuns(build)}">${it.getRunningRuns(build)}</td>
+					<td data="${it.getWaitingRuns(build)}">${it.getWaitingRuns(build)}</td>
+					<td data="${it.getOtherRuns(build)}">${it.getOtherRuns(build)}</td>
+					<td data="${it.getTotalSessions(build)}">${it.getTotalSessions(build)}</td>
 
-            </tr>
-        </j:forEach>
-    </table>
-    <!--t:buildListTable builds="${builds}" jobBaseUrl="" /-->
+				</tr>
+			</j:forEach>
+		</tbody>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/DSLBuildAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/DSLBuildAction/index.jelly
@@ -1,26 +1,32 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" >
     <l:layout>
         <st:include it="${it.build}" page="sidepanel.jelly" optional="true"/>
         <l:main-panel>
-            <h2><img src="/plugin/vmanager-plugin/img/weblinks.png" style="width: 32px; height: 32px; margin-right: 10px;"/>${it.DisplayName}</h2>
-            <h4>Build #${it.buildNumber}'s sessions:</h4>
-            <j:set var="sessionId" value="${it.getJobSessions()}"/>
-            <table id="statistics" class="sortable pane bigtable" style="margin-top: 0px;">
-                <tr style="border-top: 0px;">
-                    <th align="left">Session Name</th>
-                    <th align="left">Session ID</th>
-                    <th align="left">Verisium Manager Web</th>
-                </tr>
+        <h2>${it.DisplayName}</h2>
+        <h4>Build #${it.buildNumber}'s sessions:</h4>
+        <j:set var="sessionId" value="${it.getJobSessions()}"/>
+        <t:setIconSize/>
+        <table class="jenkins-table sortable ${iconSize == '16x16' ? 'jenkins-table--small' : iconSize == '24x24' ? 'jenkins-table--medium' : ''}">
+        <thead>
+            <tr>
+                <th align="left">Session Name</th>
+                <th align="left">Session ID</th>
+                <th align="left">Verisium Manager Web</th>
+            </tr>
+        </thead>
+        <tbody>
             <j:forEach var="session" items="${sessionId}">
                     <tr>    
-                        <td style="border: 1px #bbb solid;" data="${it.getSessionName(session)}">${it.getSessionName(session)}</td>
-                        <td style="border: 1px #bbb solid;" data="${session}">${session}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getSessionLinkForBuild(session)}"><a target="_blank" href="${it.getSessionLinkForBuild(session)}" tooltip="A Link to Verisium Manager Web Regression">Link</a></td>		
+                        <td data="${it.getSessionName(session)}">${it.getSessionName(session)}</td>
+                        <td data="${session}">${session}</td>
+                        <td data="${it.getSessionLinkForBuild(session)}"><a target="_blank" href="${it.getSessionLinkForBuild(session)}" tooltip="A Link to Verisium Manager Web Regression">Link</a></td>		
                     </tr>
             </j:forEach>
-            </table>
+        </tbody>
+        </table>
+        <t:iconSize/>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/DSLBuildAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/DSLBuildAction/summary.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <t:summary icon="/plugin/vmanager-plugin/img/chart_s.png">
+    <t:summary icon="symbol-analytics-outline plugin-ionicons-api">
                 <a target="_blank" href="${it.getvManagerLink(true)}">Verisium Manager Analysis</a>
     </t:summary>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/DSLProjectAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/DSLProjectAction/index.jelly
@@ -1,14 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
-    <j:set var="iconSize" value="16x16" />
     <l:layout>
         <st:include it="${it.project}" page="sidepanel.jelly" optional="true"/>
         <l:main-panel>
-            <h2><img src="/plugin/vmanager-plugin/img/project_icon.png" style="width: 32px; height: 32px; margin-right: 10px;"/>${it.DisplayName}</h2>
+            <h2>${it.DisplayName}</h2>
             <h4>Project: ${it.ProjectName} (showing last 15 builds)</h4>
             <j:set var="vmgrBuilds" value="${it.getFinishedVMGRBuilds()}"/>
-            <table id="statistics" class="sortable pane bigtable" style="margin-top: 0px;">
+            <t:setIconSize/>
+            <table class="jenkins-table sortable ${iconSize == '16x16' ? 'jenkins-table--small' : iconSize == '24x24' ? 'jenkins-table--medium' : ''}">
+            <thead id="statistics">
                 <tr style="border-top: 0px;">
                     <th align="left">Build</th>
                     <th align="left">Time</th>
@@ -24,30 +25,39 @@
                     <th align="left">#Other</th>
                     <th align="left">#Sessions</th>
                 </tr>
+            </thead>
+            <tbody>
             <j:forEach var="build" items="${vmgrBuilds}">
-                    <!--p>${projectMessage}</p-->
+                    
                     <tr>
                         
-                        <td style="border: 1px #bbb solid;" data="${it.getBuildColumnSortData(build)}">
-                            <a href="${h.getRelativeLinkTo(build.getRun().parent)}/${build.getRun().number}" >
-                                <img src="${imagesURL}/16x16/${build.getRun().buildStatusUrl}" alt="${build.getRun().iconColor.description}" title="${build.getRun().iconColor.description}" />${build.getRun().displayName}
+                        <td data="${it.getBuildColumnSortData(build)}">
+                            <div class="dbv-cell">
+                            <l:icon alt="${build.getRun().iconColor.description}"
+                                    class="${build.getRun().buildStatusIconClassName} icon-sm"/>
+                            <a href="${h.getRelativeLinkTo(build.getRun().parent)}/${build.getRun().number}" class="model-link"
+                                tooltip="${empty(build.getRun().description) ? null : app.markupFormatter.translate(build.getRun().description)}">
+                                ${build.getRun().displayName}
                             </a>
+                            </div>
                         </td>
-                        <td style="border: 1px #bbb solid;" data="${it.getTimestampString(build)}">${it.getTimestampString(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getBuildOwner(build)}">${it.getBuildOwner(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getSessionStatus(build)}">${it.getSessionStatus(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getSessionTriage(build)}"><a target="_blank" href="${it.getSessionTriage(build)}" tooltip="A Link to Verisium Manager Web Regression">Link</a></td>		
-                        <td style="border: 1px #bbb solid;" data="${it.getSessionName(build)}">${it.getSessionName(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getTotalRuns(build)}">${it.getTotalRuns(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getPassedRuns(build)}">${it.getPassedRuns(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getFailedRuns(build)}">${it.getFailedRuns(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getRunningRuns(build)}">${it.getRunningRuns(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getWaitingRuns(build)}">${it.getWaitingRuns(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getOtherRuns(build)}">${it.getOtherRuns(build)}</td>
-                        <td style="border: 1px #bbb solid;" data="${it.getTotalSessions(build)}">${it.getTotalSessions(build)}</td>
+                        <td data="${it.getTimestampSortData(build)}">${it.getTimestampString(build)}</td>
+                        <td data="${it.getBuildOwner(build)}">${it.getBuildOwner(build)}</td>
+                        <td data="${it.getSessionStatus(build)}">${it.getSessionStatus(build)}</td>
+                        <td data="${it.getSessionTriage(build)}"><a target="_blank" href="${it.getSessionTriage(build)}" tooltip="A Link to Verisium Manager Web Regression">Link</a></td>		
+                        <td data="${it.getSessionName(build)}">${it.getSessionName(build)}</td>
+                        <td data="${it.getTotalRuns(build)}">${it.getTotalRuns(build)}</td>
+                        <td data="${it.getPassedRuns(build)}">${it.getPassedRuns(build)}</td>
+                        <td data="${it.getFailedRuns(build)}">${it.getFailedRuns(build)}</td>
+                        <td data="${it.getRunningRuns(build)}">${it.getRunningRuns(build)}</td>
+                        <td data="${it.getWaitingRuns(build)}">${it.getWaitingRuns(build)}</td>
+                        <td data="${it.getOtherRuns(build)}">${it.getOtherRuns(build)}</td>
+                        <td data="${it.getTotalSessions(build)}">${it.getTotalSessions(build)}</td>
                     </tr>
             </j:forEach>
+            </tbody>
             </table>
+            <t:iconSize/>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/ReportBuildAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vmanager/dsl/post/ReportBuildAction/index.jelly
@@ -6,7 +6,7 @@
     <l:layout>
         <st:include it="${it.build}" page="sidepanel.jelly" optional="true"/>
         <l:main-panel>
-	    <h2><img src="/plugin/vmanager-plugin/img/report.png" style="width: 32px; height: 32px; margin-right: 10px;"/>${it.DisplayName}</h2>
+	    <h2>${it.DisplayName}</h2>
             <div id="reportLoading" class="microAgentWaiting"><div class="loaderMicro"><div class="loader-waiting"><div class="loader"></div></div></div><div class="spinnerMicroAgentMessage"><p>Loading the report. Please wait...</p></div></div>
             <div id="reportContent" class="contentWrapper">${h.rawHtml(it.getReportFromWorkspace())}</div>
              		


### PR DESCRIPTION
-	Breaking Change - Only compatible with Jenkins version 2.479 and higher
-	Added Support in Java 17
-	Resolved the problem where the user password was being reset after every configuration save
-	Move the PostStep Report to stream directly from the server to the disk
-	Adjusted tables and icons to Jenkins new CSS
-	Enabled CD (Continuous Delivery)